### PR TITLE
Option to add colons to input emoji list

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Use the `-e` or `--emojis` flag to use a custom list of emojis.
 python partyparrot.py "something stupid" -e ":emoji1:" ":emoji2:" ":emoji3:" ":emoji4:" | pbcopy
 ```
 
+## For the lazy
+
+Use the `-c` or `--colons` flag to add colons around your inputs for custom emoji.
+
+```bash
+python partyparrot.py "AMAZING" -e "parrotwave1" "parrotwave2" "parrotwave3" | pbcopy
+```
+
 ## Auto-Post to Slack
 
 Use the `-f` or `--force` flag to auto-post to your favorite Slack channel (configure URL in the "Incoming Webhooks" section of the "Integrations" page).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ python partyparrot.py "something stupid" -e ":emoji1:" ":emoji2:" ":emoji3:" ":e
 Use the `-c` or `--colons` flag to add colons around your inputs for custom emoji.
 
 ```bash
-python partyparrot.py "AMAZING" -e "parrotwave1" "parrotwave2" "parrotwave3" | pbcopy
+python partyparrot.py "AMAZING" -c -e "parrotwave1" "parrotwave2" "parrotwave3" | pbcopy
 ```
 
 ## Auto-Post to Slack

--- a/partyparrot.py
+++ b/partyparrot.py
@@ -44,7 +44,9 @@ def post_text_to_slack(output_string):
     return requests.post(os.environ['SHITPOSTING_ENDPOINT'], data=json.dumps(payload))
 
 
-def convert_str_to_emoji(s, emojis=PARTY_PARROTS, space=' ', force=False):
+def convert_str_to_emoji(s, emojis=PARTY_PARROTS, space=' ', force=False, colons=False):
+    if colons:
+      emojis = [':' + emoji + ':' for emoji in emojis]
 
     emoji_iterator = itertools.cycle(emojis)
 
@@ -60,7 +62,8 @@ def convert_str_to_emoji(s, emojis=PARTY_PARROTS, space=' ', force=False):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('text', help='The text to emoji-fy')
-    parser.add_argument('-e', '--emojis', nargs='+', help='List of emojis to use.', default=PARTY_PARROTS)
+    parser.add_argument('-e', '--emojis', nargs='+', help='List of emojis to use.', default=PARTY_PARROTS),
+    parser.add_argument('-c', '--colons', action='store_true', help="Add colons around the input emoji."),
     parser.add_argument('-f', '--force', action='store_true', help='automatically post to the slack of your choosing', default=False)
     parser.add_argument('-s', '--space', default='        ')
 
@@ -70,7 +73,8 @@ if __name__ == '__main__':
         out_str = convert_str_to_emoji(args.text,
                                        emojis=args.emojis,
                                        space=args.space,
-                                       force=args.force
+                                       force=args.force,
+                                       colons=args.colons
                                        )
         print(out_str)
     except ValueError as e:

--- a/test_partyparrot.py
+++ b/test_partyparrot.py
@@ -31,6 +31,12 @@ class TestPartyParrot(unittest.TestCase):
             self.number_result
         )
 
+    def test_add_colons(self):
+        self.assertEqual(
+          partyparrot.convert_str_to_emoji('TEST', emojis=['partyparrot'], colons=True),
+          self.partyparrot_result
+        )
+
     def test_invalid_character(self):
         with self.assertRaises(ValueError):
             partyparrot.convert_str_to_emoji('TEST_')


### PR DESCRIPTION
Prevent repetitive stress injury

Instead of
```bash
python partyparrot.py "whooooo" -e ":parrotwave1:" ":parrotwave2:" ":parrotwave3:" ":parrotwave4:" ":parrotwave5:" ":parrotwave6:" ":parrotwave7:"| pbcopy
```

you can just type
```bash
python partyparrot.py "whooooo" -c -e "parrotwave1" "parrotwave2" "parrotwave3" "parrotwave4" "parrotwave5" "parrotwave6" "parrotwave7" | pbcopy
```